### PR TITLE
Add a `.gitignore` file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+/composer.lock


### PR DESCRIPTION
`Hoa\Consistency\Xcallable` use `Hoa\Stream` and so the dependency must not be a *require-dev*.

https://github.com/hoaproject/Consistency/blob/master/Xcallable.php#L40