### PR TITLE
Fix TLSv* constants notices on PHP 5.5.

### DIFF
--- a/Consistency.php
+++ b/Consistency.php
@@ -104,7 +104,7 @@ class Consistency
      * Whether a word is reserved or not.
      *
      * @param   string  $word    Word.
-     * @return  void
+     * @return  bool
      */
     public static function isKeyword($word)
     {
@@ -278,14 +278,14 @@ class Consistency
 namespace
 {
 
-/**
- * Implement a fake `trait_exists` function.
- *
- * @param   string  $traitname    Traitname.
- * @param   bool    $autoload     Autoload.
- * @return  bool
- */
 if (!function_exists('trait_exists')) {
+    /**
+     * Implement a fake `trait_exists` function.
+     *
+     * @param   string  $traitname    Traitname.
+     * @param   bool    $autoload     Autoload.
+     * @return  bool
+     */
     function trait_exists($traitname, $autoload = true)
     {
         if (true === $autoload) {
@@ -314,26 +314,49 @@ if (70000 > PHP_VERSION_ID && false === interface_exists('Throwable', false)) {
 }
 
 /**
- * Curry.
- * Example:
- *     $c = curry('str_replace', …, …, 'foobar');
- *     var_dump($c('foo', 'baz')); // bazbar
- *     $c = curry('str_replace', 'foo', 'baz', …);
- *     var_dump($c('foobarbaz')); // bazbarbaz
- * Nested curries also work:
- *     $c1 = curry('str_replace', …, …, 'foobar');
- *     $c2 = curry($c1, 'foo', …);
- *     var_dump($c2('baz')); // bazbar
- * Obviously, as the first argument is a callable, we can combine this with
- * \Hoa\Consistency\Xcallable ;-).
- * The “…” character is the HORIZONTAL ELLIPSIS Unicode character (Unicode:
- * 2026, UTF-8: E2 80 A6).
- *
- * @param   mixed  $callable    Callable (two parts).
- * @param   ...    ...          Arguments.
- * @return  \Closure
+ * Define TLSv* constants, introduced in PHP 5.5.
  */
+if (50600 > PHP_VERSION_ID) {
+    $define = function ($constantName, $constantValue, $case = false) {
+        if (!defined($constantName)) {
+            return define($constantName, $constantValue, $case);
+        }
+
+        return false;
+    };
+
+    $define('STREAM_CRYPTO_METHOD_TLSv1_0_SERVER', 8);
+    $define('STREAM_CRYPTO_METHOD_TLSv1_1_SERVER', 16);
+    $define('STREAM_CRYPTO_METHOD_TLSv1_2_SERVER', 32);
+    $define('STREAM_CRYPTO_METHOD_ANY_SERVER', 62);
+
+    $define('STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT', 9);
+    $define('STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT', 17);
+    $define('STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT', 33);
+    $define('STREAM_CRYPTO_METHOD_ANY_CLIENT', 63);
+}
+
 if (!function_exists('curry')) {
+    /**
+     * Curry.
+     * Example:
+     *     $c = curry('str_replace', …, …, 'foobar');
+     *     var_dump($c('foo', 'baz')); // bazbar
+     *     $c = curry('str_replace', 'foo', 'baz', …);
+     *     var_dump($c('foobarbaz')); // bazbarbaz
+     * Nested curries also work:
+     *     $c1 = curry('str_replace', …, …, 'foobar');
+     *     $c2 = curry($c1, 'foo', …);
+     *     var_dump($c2('baz')); // bazbar
+     * Obviously, as the first argument is a callable, we can combine this with
+     * \Hoa\Consistency\Xcallable ;-).
+     * The “…” character is the HORIZONTAL ELLIPSIS Unicode character (Unicode:
+     * 2026, UTF-8: E2 80 A6).
+     *
+     * @param   mixed  $callable    Callable (two parts).
+     * @param   ...    ...          Arguments.
+     * @return  \Closure
+     */
     function curry($callable)
     {
         $arguments = func_get_args();


### PR DESCRIPTION
Fix https://github.com/hoaproject/Socket/issues/38

May be it can be better to move `Throwable` and these constants to a dedicated file ?