### PR TITLE
Add void as reserved keyword

### DIFF
--- a/Consistency.php
+++ b/Consistency.php
@@ -184,6 +184,7 @@ class Consistency
             'unset',
             'use',
             'var',
+            'void',
             'while',
             'xor',
             'yield',

--- a/Prelude.php
+++ b/Prelude.php
@@ -70,7 +70,7 @@ $define('PHP_INT_MIN',    ~PHP_INT_MAX);
 $define('PHP_FLOAT_MIN',  (float) PHP_INT_MIN);
 $define('PHP_FLOAT_MAX',  (float) PHP_INT_MAX);
 $define('π',              M_PI);
-$define('void',           (unset) null);
+$define('nil',            (unset) null);
 $define('_public',        1);
 $define('_protected',     2);
 $define('_private',       4);

--- a/Test/Unit/Consistency.php
+++ b/Test/Unit/Consistency.php
@@ -198,6 +198,7 @@ class Consistency extends Test\Unit\Suite
                     'unset',
                     'use',
                     'var',
+                    'void',
                     'while',
                     'xor',
                     'yield',


### PR DESCRIPTION
`void` for PHP-7.1 is now a reserved keyword[1]. This patch replace the
constant `void` to the new keyword `nil` and add the keyword `void` to
the reserved keyword list.

[1] https://github.com/php/php-src/blob/php-7.1.0alpha2/UPGRADING