### PR TITLE
Consistency: Remove `trait_exists` polyfill

### DIFF
--- a/Consistency.php
+++ b/Consistency.php
@@ -278,24 +278,6 @@ class Consistency
 namespace
 {
 
-if (!function_exists('trait_exists')) {
-    /**
-     * Implement a fake `trait_exists` function.
-     *
-     * @param   string  $traitname    Traitname.
-     * @param   bool    $autoload     Autoload.
-     * @return  bool
-     */
-    function trait_exists($traitname, $autoload = true)
-    {
-        if (true === $autoload) {
-            class_exists($traitname, true);
-        }
-
-        return false;
-    }
-}
-
 if (70000 > PHP_VERSION_ID && false === interface_exists('Throwable', false)) {
     /**
      * Implement a fake Throwable class, introduced in PHP7.0.


### PR DESCRIPTION
Fix #14.

`trait_exists` lands since PHP 5.4. Because PHP 5.5 is required, this polyfill can be removed safely.