### PR TITLE
Consistency: Since PHP 7.1, identifier has changed.

### DIFF
--- a/Consistency.php
+++ b/Consistency.php
@@ -211,7 +211,7 @@ class Consistency
     public static function isIdentifier($id)
     {
         return 0 !== preg_match(
-            '#^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$#',
+            '#^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x80-\xff]*$#',
             $id
         );
     }

--- a/Test/Unit/Consistency.php
+++ b/Test/Unit/Consistency.php
@@ -223,7 +223,7 @@ class Consistency extends Test\Unit\Suite
     public function case_is_identifier()
     {
         $this
-            ->given($_identifier = $this->realdom->regex('#^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$#'))
+            ->given($_identifier = $this->realdom->regex('#^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x80-\xff]*$#'))
             ->when(function () use ($_identifier) {
                 foreach ($this->sampleMany($_identifier, 1000) as $identifier) {
                     $this


### PR DESCRIPTION
Fix #12.

The `\x7f` character has been removed from the identifier definition.