### PR TITLE
Prelude: Remove the `(unset)` cast

### DIFF
--- a/Prelude.php
+++ b/Prelude.php
@@ -70,7 +70,7 @@ $define('PHP_INT_MIN',    ~PHP_INT_MAX);
 $define('PHP_FLOAT_MIN',  (float) PHP_INT_MIN);
 $define('PHP_FLOAT_MAX',  (float) PHP_INT_MAX);
 $define('π',              M_PI);
-$define('nil',            (unset) null);
+$define('nil',            null);
 $define('_public',        1);
 $define('_protected',     2);
 $define('_private',       4);


### PR DESCRIPTION
This cast has been deprecated in PHP 7.2.