### PR TITLE
Add `hoa/devtools` to suggested packages.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,5 +41,8 @@
         "branch-alias": {
             "dev-master": "2.x-dev"
         }
+    },
+    "suggest": {
+        "hoa/devtools": "To polish the integration of Hoa inside your IDE, consider installing `hoa/devtools`."
     }
 }


### PR DESCRIPTION
As of Hoaproject/Consistency#29 mentioned, the usage of flex entity will break some static analyzer. Adding `hoa/devtools` as a dependency fix the problem at least in PHPStorm.

Must fix Hoaproject/Consistency#30.