### PR TITLE
fix opcache preload issue

### DIFF
--- a/Source/Consistency.php
+++ b/Source/Consistency.php
@@ -109,9 +109,13 @@ class Consistency
      */
     public static function flexEntity(string $entityName): bool
     {
+        $alias = static::getEntityShortestName($entityName);
+        if (class_exists($alias, false)) {
+            return true;
+        }
         return class_alias(
             $entityName,
-            static::getEntityShortestName($entityName),
+            $alias,
             false
         );
     }


### PR DESCRIPTION
```
Warning: Cannot declare class Hoa\Consistency, because the name is already in use
```
when using opcache.preload

also relates to https://github.com/hoaproject/Consistency/issues/35 but for earlier release (1.17.05.02)